### PR TITLE
fix: workaround for #33, run a yarn build in postinstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "main": "index.js",
   "repository": "https://github.com/Conflux-Chain/conflux-developer-site.git",
   "scripts": {
+    "postinstall": "cfxdoc build",
     "start": "cfxdoc start",
     "build": "cfxdoc build"
   },


### PR DESCRIPTION
Currently

1. `yarn start` without ever running `yarn build` leads to sidebar missing 
2. first `yarn build` produces pages without sidebar

So this pr adds a `postinstall` script in package.json as a tmp workaround.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-developer-site/34)
<!-- Reviewable:end -->
