### PR TITLE
Add pub-sub docs

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -40,6 +40,7 @@ module.exports = {
       label: "SDK",
       items: [
         { type: "doc", folder: "conflux-doc", id: "json_rpc" },
+        { type: "doc", folder: "conflux-doc", id: "pubsub" },
         { type: "doc", folder: "conflux-doc", id: "cli_sub_commands" },
         { type: "doc", folder: "js-conflux-sdk", id: "javascript_sdk" },
         { type: "doc", folder: "go-conflux-sdk", id: "go_sdk" },


### PR DESCRIPTION
Syntax highlighting in the last section (*Node.js example*) seems to be broken... Should I change from ```` ```node```` to ```` ```js````?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-developer-site/35)
<!-- Reviewable:end -->
